### PR TITLE
Fixed data race in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ _testmain.go
 
 # Ignore JetBrains IDE Project Files
 .idea
+/crypt

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: fmt
+fmt:
+	gofmt -l -w `find . -type f -name '*.go' -not -path "./vendor/*"`
+	goimports -l -w `find . -type f -name '*.go' -not -path "./vendor/*"`


### PR DESCRIPTION
Without this PR there is data race fail when I run tests:
```bash
$: go test -race ./...
?   	github.com/bketelsen/crypt/backend	[no test files]
?   	github.com/bketelsen/crypt/backend/consul	[no test files]
?   	github.com/bketelsen/crypt/backend/etcd	[no test files]
?   	github.com/bketelsen/crypt/backend/mock	[no test files]
?   	github.com/bketelsen/crypt/bin/crypt	[no test files]
==================
WARNING: DATA RACE
Write at 0x00c0000b1ef0 by goroutine 13:
  runtime.mapassign_faststr()
      /usr/local/Cellar/go/1.12.7/libexec/src/runtime/map_faststr.go:202 +0x0
  github.com/bketelsen/crypt/backend/mock.(*Client).Set()
      /gopath/src/github.com/bketelsen/crypt/backend/mock/mock.go:46 +0x6e
  github.com/bketelsen/crypt/config.configManager.Set()
      /gopath/src/github.com/bketelsen/crypt/config/config.go:146 +0x1c2
  github.com/bketelsen/crypt/config.(*configManager).Set()
      <autogenerated>:1 +0x102
  github.com/bketelsen/crypt/config.Test_Set_BasePath()
      /gopath/src/github.com/bketelsen/crypt/config/config_test.go:194 +0x20c
  testing.tRunner()
      /usr/local/Cellar/go/1.12.7/libexec/src/testing/testing.go:865 +0x163

Previous read at 0x00c0000b1ef0 by goroutine 11:
  runtime.mapaccess2_faststr()
      /usr/local/Cellar/go/1.12.7/libexec/src/runtime/map_faststr.go:107 +0x0
  github.com/bketelsen/crypt/backend/mock.(*Client).Watch.func1()
      /gopath/src/github.com/bketelsen/crypt/backend/mock/mock.go:27 +0x86

Goroutine 13 (running) created at:
  testing.(*T).Run()
      /usr/local/Cellar/go/1.12.7/libexec/src/testing/testing.go:916 +0x65a
  testing.runTests.func1()
      /usr/local/Cellar/go/1.12.7/libexec/src/testing/testing.go:1157 +0xa8
  testing.tRunner()
      /usr/local/Cellar/go/1.12.7/libexec/src/testing/testing.go:865 +0x163
  testing.runTests()
      /usr/local/Cellar/go/1.12.7/libexec/src/testing/testing.go:1155 +0x523
  testing.(*M).Run()
      /usr/local/Cellar/go/1.12.7/libexec/src/testing/testing.go:1072 +0x2eb
  main.main()
      _testmain.go:56 +0x222

Goroutine 11 (running) created at:
  github.com/bketelsen/crypt/backend/mock.(*Client).Watch()
      /gopath/src/github.com/bketelsen/crypt/backend/mock/mock.go:52 +0x8c
  github.com/bketelsen/crypt/config.standardConfigManager.Watch()
      /gopath/src/github.com/bketelsen/crypt/config/config.go:185 +0x83
  github.com/bketelsen/crypt/config.(*standardConfigManager).Watch()
      <autogenerated>:1 +0x8b
  github.com/bketelsen/crypt/config.Test_StandardWatch_BasePath()
      /gopath/src/github.com/bketelsen/crypt/config/config_test.go:173 +0x101
  testing.tRunner()
      /usr/local/Cellar/go/1.12.7/libexec/src/testing/testing.go:865 +0x163
==================
--- FAIL: Test_Set_BasePath (0.00s)
    testing.go:809: race detected during execution of test
FAIL
FAIL	github.com/bketelsen/crypt/config	0.039s
ok  	github.com/bketelsen/crypt/encoding/secconf	(cached)
```

PR fixes mock which is using for tests. So, now output is like this one:
```bash
$: go test -race ./...
?   	github.com/bketelsen/crypt/backend	[no test files]
?   	github.com/bketelsen/crypt/backend/consul	[no test files]
?   	github.com/bketelsen/crypt/backend/etcd	[no test files]
?   	github.com/bketelsen/crypt/backend/mock	[no test files]
?   	github.com/bketelsen/crypt/bin/crypt	[no test files]
ok  	github.com/bketelsen/crypt/config	1.049s
ok  	github.com/bketelsen/crypt/encoding/secconf	(cached)
```