### PR TITLE
fix vulnerability: CVE-2020-15114 in etcd v3.3.13+incompatible

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	cloud.google.com/go/firestore v1.1.0
-	github.com/coreos/etcd v3.3.13+incompatible
+	github.com/coreos/etcd v3.3.24+incompatible
 	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/google/btree v1.0.0 // indirect
 	github.com/hashicorp/consul/api v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,7 @@ github.com/bketelsen/crypt v0.0.2/go.mod h1:QoWTRmAOKpT3wAaYuPKutmL1eJqFHPUTt8Ez
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/etcd v3.3.13+incompatible h1:8F3hqu9fGYLBifCmRCJsicFqDx/D68Rt3q1JMazcgBQ=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
+github.com/coreos/etcd v3.3.24+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-semver v0.3.0 h1:wkHLiw0WNATZnSG7epLsujiMCgPAc9xhjJ4tgnAxmfM=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
We're using `Viper` in [nancy](https://github.com/sonatype-nexus-community/nancy), and `Viper` uses `crypt`.

During a recent CI build, nancy discovered a vulnerability in the `crypt` transitive dependency. This PR updates the dependency version to use a newly released update of `etcd`. This transitive dep is pulled in by `github.com/bketelsen/crypt`.

Fixes Issue #9 