### PR TITLE
Small fixes and docs touch-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # crypt
 
-**This is a maintained fork of the abandoned [original](https://github.com/bketelsen/crypt)**
+**This is a maintained fork of the abandoned [original](https://github.com/xordataexchange/crypt)**
 
 You can use crypt as a command line tool or as a configuration library:
 
@@ -19,7 +19,7 @@ The crypt cli and config package require gpg keyrings.
 
 ### Create a key and keyring from a batch file
 
-```
+```bash
 vim app.batch
 ```
 
@@ -39,7 +39,7 @@ Expire-Date: 0
 
 Run the following command:
 
-```
+```bash
 gpg2 --batch --armor --gen-key app.batch
 ```
 

--- a/bin/crypt/README.md
+++ b/bin/crypt/README.md
@@ -2,18 +2,8 @@
 
 ## Install
 
-### Binary release
-
-```
-wget https://github.com/bketelsen/crypt/releases/download/v0.0.1/crypt-0.0.1-linux-amd64
-mv crypt-0.0.1-linux-amd64 /usr/local/bin/crypt
-chmod +x /usr/local/bin/crypt
-```
-
-### go install
-
-```
-go install github.com/bketelsen/crypt/bin/crypt
+```bash
+go install github.com/bketelsen/crypt/bin/crypt@latest
 ```
 
 ## Backends
@@ -41,7 +31,7 @@ usage: crypt set [args...] key file
 
 Example:
 
-```
+```bash
 crypt set -keyring pubring.gpg /app/config config.json 
 ```
 
@@ -56,15 +46,17 @@ usage: crypt get [args...] key
 
 Example:
 
-```
+```bash
 crypt get -secret-keyring secring.gpg /app/config
 ```
 
 ### Support for unencrypted values
-```
+
+```bash
 crypt set -plaintext ...
 crypt get -plaintext ...
 ```
+
 Crypt now has support for getting and setting plain unencrypted values, as
 a convenience.  This was added to the backend libraries so it could be exposed
 in spf13/viper. Use the -plaintext flag to get or set a value without encryption. 

--- a/bin/crypt/cmd.go
+++ b/bin/crypt/cmd.go
@@ -48,7 +48,7 @@ func getCmd(flagset *flag.FlagSet) {
 
 func getEncrypted(key, keyring string, store backend.Store) ([]byte, error) {
 	var value []byte
-	kr, err := os.Open(secretKeyring)
+	kr, err := os.Open(keyring)
 	if err != nil {
 		return value, err
 	}
@@ -111,7 +111,7 @@ func listCmd(flagset *flag.FlagSet) {
 }
 
 func listEncrypted(key, keyring string, store backend.Store) (backend.KVPairs, error) {
-	kr, err := os.Open(secretKeyring)
+	kr, err := os.Open(keyring)
 	if err != nil {
 		return nil, err
 	}

--- a/bin/crypt/main.go
+++ b/bin/crypt/main.go
@@ -45,14 +45,16 @@ func main() {
 }
 
 func help() {
-	fmt.Fprintf(os.Stderr, "usage: %s COMMAND [arg...]", os.Args[0])
-	fmt.Fprintf(os.Stderr, "\n\n")
-	fmt.Fprintf(os.Stderr, "commands:\n")
-	fmt.Fprintf(os.Stderr, "   get   retrieve the value of a key\n")
-	fmt.Fprintf(os.Stderr, "   list  retrieve all values under a key\n")
-	fmt.Fprintf(os.Stderr, "   set   set the value of a key\n")
-	fmt.Fprintf(os.Stderr, "\n")
-	fmt.Fprintf(os.Stderr, "-plaintext  don't encrypt or decrypt the values before storage or retrieval\n")
+	const usage = `usage: %s COMMAND [arg...]
 
+commands:
+   get   retrieve the value of a key
+   list  retrieve all values under a key
+   set   set the value of a key
+
+-plaintext  don't encrypt or decrypt the values before storage or retrieval
+`
+
+	_, _ = fmt.Fprintf(os.Stderr, usage, os.Args[0])
 	os.Exit(1)
 }

--- a/config/README.md
+++ b/config/README.md
@@ -4,7 +4,7 @@
 
 ### Get configuration from a backend
 
-```
+```go
 package main
 
 import (
@@ -41,7 +41,7 @@ func main() {
 
 ### Monitor backend for configuration changes
 
-```
+```go
 package main
 
 import (


### PR DESCRIPTION
### various docs touch-ups:

- add language hints to examples to enable highlighting on GitHub.
- remove "binary release" instructions, because current releases  have not released binaries.
- updated `go install` instructions for go modules (add `@latest`).
- fixed link to original github repository.

### bin/crypt: use string-literal for usage template

### bin/crypt: getEncrypted(), listEncrypted() use keyring argument

The refactor in commit https://github.com/bketelsen/crypt/commit/041620bddb3e36f59003eb6402e3703bf4969dd9 extracted this code to separate functions, which get the keyring passed as an argument, but the code was still refering the package-level `secretKeyring` variable.

In practice, this doesn't make a difference, as all uses of these functions have `secretKeyring` passed as argument, but let's change it to do the expected thing :D.
