### PR TITLE
Update golang.org/x/crypto

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mitchellh/mapstructure v1.4.1 // indirect
 	go.etcd.io/etcd/client/v2 v2.305.0
-	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5
+	golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975
 	golang.org/x/sys v0.0.0-20210909193231-528a39cd75f3 // indirect
 	google.golang.org/api v0.44.0
 	google.golang.org/grpc v1.41.0


### PR DESCRIPTION
Improper Signature Verification
Affecting golang.org/x/crypto/ssh package, versions <0.0.0-20200220183623-bac4c82f6975

https://security.snyk.io/vuln/SNYK-GOLANG-GOLANGORGXCRYPTOSSH-551923